### PR TITLE
Support a basic [props] selector

### DIFF
--- a/docs/Other_Ideas.md
+++ b/docs/Other_Ideas.md
@@ -131,30 +131,8 @@ Right now there's just `simple` and `composite` types, but we may want to suppor
 I'm thinking the best way to do this is with something like `.hasMany`:
 
 ```js
-styleStateTypes = {
+subComponentTypes = {
   indicator: SubComponentTypes.simple,
   row: SubComponentTypes.composite.hasMany,
 }
 ```
-
-### `[prop]` selector
-
-Similar to [Advanced Queries](#advanced-queries), but for props.
-
-Analagous to CSS's `[attr]` selectors, but operating directly on the component's `props`.
-
-```js
-{
-  '[checked]': { ... },
-  '[foo=42]': { ... },
-  '[bar="baz"]': { ... },
-}
-```
-
-This would reduce a lot of `getStyleState` boilerplate; most style-state is a simple passthru to props, especially stateless components.
-
-It's also a more direct reflection of the existing CSS syntax.
-
-We can use `propTypes` to validate these; very nice.
-
-Lastly -- and perhaps most importantly -- this will allow us to wrap any existing component; even third-party ones, presuming we don't need access to internal state.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -98,7 +98,7 @@ An optional (but recommended) way to declare the state your component exposes fo
 
 Takes the same form as [`propTypes`](https://facebook.github.io/react/docs/reusable-components.html#prop-validation).
 
-In a nutshell, `bool` style-state items correspond to a single [`:pseudo-selector`](#pseudo-selectors), and all other types are only accessible via [style callbacks](#stylecallbacks).
+In a nutshell, `bool` style-state items correspond to a single [`:pseudo-selector`](#-pseudo-selectors), and all other types are only accessible via [style callbacks](#stylecallbacks).
 
 Much like `propTypes`, `styleStateTypes` will help ensure your component is being styled correctly by providing warnings whenever unspecified or non-boolean style-states are used as `:pseudo-selectors`.
 
@@ -119,7 +119,7 @@ styleStateTypes: {
 
 An optional (but recommended) way to declare the styleable sub-components (if any) that your component contains.
 
-In a nutshell, each named sub-component corresponds to a single [`::pseudo-element`](#pseudo-element).
+In a nutshell, each named sub-component corresponds to a single [`::pseudo-element`](#-pseudo-element).
 
 Values must come from [`Seamstress.SubComponentTypes`](#seamstresssubcomponenttypes).
 
@@ -188,7 +188,7 @@ By default, all sub-components are assumed to be `simple`. Use [`config.subCompo
 
 A prop for expressing how a Seamstress component should be styled.
 
-Think of it as a combination of React inline styles with custom `:pseudo-selectors` and `::pseudo-elements`.
+Think of it as a combination of React inline styles with custom [`:pseudo-selectors`](#-pseudo-selectors), [`::pseudo-elements`](#-pseudo-elements), and [`[prop]` selectors](#-prop-selectors).
 
 Values can be a `string`, an `object`, a callback `function`, or an `Array` containing any combination of such types.
 
@@ -225,6 +225,27 @@ To apply a specific CSS class, provide a `string` instead of an object (i.e. `':
 > For instance, `:hover` will only apply if you explicitly keep track of the hover state and include it in the result of [`config.getStyleState()`](#config-getstylestate).
 >
 > However, ordinary CSS selectors may still be used within your actual CSS, of course! Seamstress merely combines and applies the applicable CSS classes for you.
+
+
+### [prop] selectors
+
+```js
+'[prop]': string/object/Function
+'[prop=false]': string/object/Function
+'[prop=42]': string/object/Function
+'[prop="string"]': string/object/Function
+```
+
+Seamstress implements a syntax inspired by [CSS's `[attr]` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) to allow you to style your components purely based on their props without the need to write any [`getStyleState`](#config-getstylestate) boilerplate.
+
+There are some key differences from standard CSS `[attr]` selectors, however:
+
+* Only `[prop]` and `[prop=<value>]` syntax supported.
+* `[prop]` only applies when `prop` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy).
+  * Note: boolean props can also be tested explicitly, i.e. `[prop=true]` or `[prop=false]`
+* String values must include **double-quotes**, i.e. `[prop="string"]`
+
+> Note: Seamstress examines your component's [`propTypes`](https://facebook.github.io/react/docs/reusable-components.html#prop-validation) to ensure all such selectors are valid. PropTypes-style warnings will be logged when invalid comparisons are made (i.e. `[number="this should be a number"]`).
 
 #### `:base`
 

--- a/examples/simple/src/App.js
+++ b/examples/simple/src/App.js
@@ -51,11 +51,36 @@ const BLUE_STYLE_CSS = [
   }
 ];
 
+// StatelessToggler can simply use [prop] selectors, a la vanilla CSS's [attr] selectors:
+
+const RED_STYLE_INLINE_STATELESS = {
+  border: '2px solid #c66',
+  backgroundColor: '#fbb',
+  '[toggled]': {
+    backgroundColor: '#c66',
+  },
+};
+
+const GREEN_STYLE_CSS_STATELESS = [
+  'GreenToggler',
+  {
+    '[toggled]': 'GreenToggler_toggled',
+    '[toggled]::indicator': 'GreenTogglerIndicator',
+  }
+];
+
+const BLUE_STYLE_CSS_STATELESS = [
+  'BlueToggler',
+  {
+    '[toggled]': 'BlueToggler_toggled',
+  }
+];
+
 const RedToggler = Toggler.extendStyles(RED_STYLE_CSS);
 const GreenToggler = Toggler.extendStyles(GREEN_STYLE_CSS);
 const BlueToggler = Toggler.extendStyles(BLUE_STYLE_CSS);
 
-const BlueStatelessToggler = StatelessToggler.extendStyles(BLUE_STYLE_CSS);
+const BlueStatelessToggler = StatelessToggler.extendStyles(BLUE_STYLE_CSS_STATELESS);
 
 export default class App extends Component {
   render () {
@@ -132,9 +157,9 @@ export default class App extends Component {
 
         <section>
           <h2>It also works with stateless components:</h2>
-          <StatelessToggler styles={RED_STYLE_INLINE} />
-          <StatelessToggler styles={GREEN_STYLE_CSS} toggled={true} />
-          <BlueStatelessToggler />
+          <StatelessToggler styles={RED_STYLE_INLINE_STATELESS} toggled={true} />
+          <StatelessToggler styles={GREEN_STYLE_CSS_STATELESS} toggled={true} />
+          <BlueStatelessToggler toggled={true} />
         </section>
       </div>
     );

--- a/examples/simple/src/StatelessToggler.js
+++ b/examples/simple/src/StatelessToggler.js
@@ -4,7 +4,7 @@ import React, { PropTypes } from 'react';
 const seamstressConfig = {
   styles: {
     ':base': 'Toggler',
-    ':toggled': 'Toggler_toggled',
+    '[toggled]': 'Toggler_toggled',
     '::indicator': 'TogglerIndicator',
   },
 
@@ -12,15 +12,6 @@ const seamstressConfig = {
     indicator: Seamstress.SubComponentTypes.simple,
   },
 
-  styleStateTypes: {
-    toggled: PropTypes.bool.isRequired,
-  },
-
-  getStyleState: ({props, context}) => {
-    return {
-      toggled: !!props.toggled,
-    };
-  },
 };
 
 function StatelessToggler (props) {
@@ -33,8 +24,6 @@ function StatelessToggler (props) {
   </div>;
 }
 
-StatelessToggler = Seamstress.createContainer(StatelessToggler, seamstressConfig);
-
 StatelessToggler.propTypes = {
   toggled: PropTypes.bool,
 };
@@ -45,4 +34,4 @@ StatelessToggler.defaultProps = {
 
 StatelessToggler.displayName = 'StatelessToggler';
 
-export default StatelessToggler;
+export default Seamstress.createContainer(StatelessToggler, seamstressConfig);

--- a/src/computeStylesFromState.js
+++ b/src/computeStylesFromState.js
@@ -2,11 +2,12 @@ import arrayify from './arrayify';
 import getExpectedPropsFromSelector from './getExpectedPropsFromSelector';
 import getAllMatches from './getAllMatches';
 
-const selectorRegex = /:(\w+)/g;
+const selectorRegex = /:([\w-_]+)/g;
+const elementRegex = /::([\w-_]+)/g;
 
 function makeStateSatisfactionChecker (state) {
   return function (propString) {
-    const propNames = getAllMatches(selectorRegex, propString).map(matches => matches[1]).filter(m => !!m);
+    const propNames = getAllMatches(selectorRegex, propString.replace(elementRegex, '')).map(matches => matches[1]).filter(m => !!m);
     return propNames.every(p => !!state[p]);
   }
 }

--- a/src/getAllMatches.js
+++ b/src/getAllMatches.js
@@ -1,0 +1,10 @@
+export default function getAllMatches (regexp, str) {
+  const results = [];
+  
+  let result;
+  while ((result = regexp.exec(str)) !== null) {
+    results.push(result);
+  }
+
+  return results;
+}

--- a/src/getExpectedPropsFromSelector.js
+++ b/src/getExpectedPropsFromSelector.js
@@ -16,7 +16,7 @@ export default function getExpectedPropsFromSelector (str) {
       try {
         expectedValue = JSON.parse(unparsedValue);
       } catch (e) {
-        throw new TypeError(`Seamstress: Malformed [prop] selector: "${str}"; did you forget to quote a string?`);
+        throw new SyntaxError(`Seamstress: Malformed [prop] selector: "${str}"; did you forget to quote a string?`);
       }
     }
 

--- a/src/getExpectedPropsFromSelector.js
+++ b/src/getExpectedPropsFromSelector.js
@@ -1,0 +1,27 @@
+import getAllMatches from './getAllMatches';
+
+const propRegex = /\[\s*(\w+)\s*(\s*=\s*([^\]]+)\s*)?\s*\]/g;
+
+export default function getExpectedPropsFromSelector (str) {
+  return getAllMatches(propRegex, str).filter(([, propName]) => {
+    return !!propName;
+  }).reduce((propValues, matches) => {
+    const [ , propName, , unparsedValue ] = matches;
+    
+    let expectedValue;
+
+    if (unparsedValue === undefined) {
+      expectedValue = undefined;
+    } else {
+      try {
+        expectedValue = JSON.parse(unparsedValue);
+      } catch (e) {
+        throw new TypeError(`Seamstress: Malformed [prop] selector: "${str}"; did you forget to quote a string?`);
+      }
+    }
+
+    propValues[propName] = expectedValue;
+
+    return propValues
+  }, {});
+}

--- a/src/getSubComponentStyles.js
+++ b/src/getSubComponentStyles.js
@@ -16,7 +16,7 @@ export default function getSubComponentStyles ({styles=[]}) {
         let value = style[propName];
         if ((/^::/).test(propName)) {
           subComponentName = propName.substr(2);
-        } else if ((/^:/).test(propName)) {
+        } else {
           const subComponentIndicatorIdx = propName.indexOf('::');
           const selector = propName.substr(0, subComponentIndicatorIdx);
           subComponentName = propName.substr(subComponentIndicatorIdx + 2);

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function getDisplayName (Component) {
 }
 
 function configureSeamstress (config={}) {
-  let {
+  const {
     styles={},
     styleStateTypes,
     getStyleState=() => { return {}; },

--- a/src/index.js
+++ b/src/index.js
@@ -34,10 +34,10 @@ function getDisplayName (Component) {
 }
 
 function configureSeamstress (config={}) {
-  const {
+  let {
     styles={},
     styleStateTypes,
-    getStyleState=(_ => {}),
+    getStyleState=() => { return {}; },
   } = config;
 
   const __subComponentTypes = config.subComponentTypes || {};
@@ -61,7 +61,7 @@ function configureSeamstress (config={}) {
     }
 
     function getComputedStyles ({ props, context, state }) {
-      const styleState = getStyleState({props, context, state}) || {};
+      const styleState = getStyleState({props, context, state});
 
       if (__DEV__) {
         const addendum = `Check the \`getStyleState()\` function supplied to the Seamstress config of \`${displayName}\`.`;

--- a/src/index.js
+++ b/src/index.js
@@ -78,10 +78,10 @@ function configureSeamstress (config={}) {
         const { propTypes } = Component;
 
         if (propTypes) {
-          const addendum = `Check the \`styles\` prop supplied to the Seamstress config of \`${displayName}\`.`;
           [...arrayify(styles), ...arrayify(props.styles)].filter(s => !!s && (typeof s === 'object')).forEach((styles) => {
             Object.keys(styles).forEach((propString) => {
               const expectedProps = getExpectedPropsFromSelector(propString);
+              const addendum = `\n\nHint: The invalid prop selector in question is \`${propString}\`.`;
               checkPropTypes(displayName, propTypes, expectedProps, 'prop', '[prop] selector type', addendum);
             });
           });

--- a/test/computeStylesFromState.js
+++ b/test/computeStylesFromState.js
@@ -836,5 +836,40 @@ runTests({
       ],
     },
 
+    {
+      capability: 'include :hyphenated-selectors',
+      input: {
+        styles: [
+          {
+            ':valid-hyphenated': 'Yep',
+          }
+        ],
+
+        state: {
+          'valid-hyphenated': true,
+        },
+      },
+      expected: [
+        'Yep'
+      ],
+    },
+
+    {
+      capability: 'include [hyphenated-prop-selectors]',
+      input: {
+        styles: [
+          {
+            '[valid-hyphenated]': 'Yep',
+          }
+        ],
+
+        props: {
+          'valid-hyphenated': true,
+        },
+      },
+      expected: [
+        'Yep'
+      ],
+    },
   ],
 });

--- a/test/computeStylesFromState.js
+++ b/test/computeStylesFromState.js
@@ -635,5 +635,132 @@ runTests({
         {'::pseudo-element': 'Yep'},
       ],
     },
+
+    {
+      capability: 'include [truthyProps]',
+      input: {
+        styles: [
+          {
+            '[valid]': 'Yep',
+            '[alsoValid]': 'Totally',
+          }
+        ],
+
+        props: {
+          valid: true,
+          alsoValid: 1,
+        },
+      },
+      expected: [
+        'Yep',
+        'Totally',
+      ],
+    },
+
+    {
+      capability: 'not include [falsyProps]',
+      input: {
+        styles: [
+          {
+            '[invalid]': 'Nope',
+            '[alsoInvalid]': 'Nah',
+          }
+        ],
+
+        props: {
+          invalid: false,
+          alsoInvalid: null,
+        },
+      },
+      expected: [
+      ],
+    },
+
+    {
+      capability: 'not include [falsyProps]',
+      input: {
+        styles: [
+          {
+            '[doesntEvenExist]': 'NoWay',
+          }
+        ],
+
+        props: {
+        },
+      },
+      expected: [
+      ],
+    },
+
+    {
+      capability: 'include numeric prop equalities',
+      input: {
+        styles: [
+          {
+            '[answer=42]': 'Valid',
+          }
+        ],
+
+        props: {
+          answer: 42,
+        },
+      },
+      expected: [
+        'Valid',
+      ],
+    },
+
+    {
+      capability: 'not include numeric prop inequalities',
+      input: {
+        styles: [
+          {
+            '[answer=42]': 'Valid',
+          }
+        ],
+
+        props: {
+          answer: 43,
+        },
+      },
+      expected: [
+      ],
+    },
+
+    {
+      capability: 'include string prop equalities',
+      input: {
+        styles: [
+          {
+            '[favoriteColor="red"]': 'LikesRed',
+          }
+        ],
+
+        props: {
+          favoriteColor: 'red',
+        },
+      },
+      expected: [
+        'LikesRed',
+      ],
+    },
+
+    {
+      capability: 'not include string prop inequalities',
+      input: {
+        styles: [
+          {
+            '[favoriteColor="red"]': 'LikesRed',
+          }
+        ],
+
+        props: {
+          favoriteColor: 'green',
+        },
+      },
+      expected: [
+      ],
+    },
+
   ],
 });

--- a/test/computeStylesFromState.js
+++ b/test/computeStylesFromState.js
@@ -871,5 +871,25 @@ runTests({
         'Yep'
       ],
     },
+
+    {
+      capability: 'include props in callbacks',
+      input: {
+        styles: [
+          {
+            color: (styleState, props) => {
+              return props.favoriteColor;
+            },
+          }
+        ],
+
+        props: {
+          favoriteColor: 'red',
+        }
+      },
+      expected: [
+        {color: 'red'},
+      ],
+    },
   ],
 });

--- a/test/computeStylesFromState.js
+++ b/test/computeStylesFromState.js
@@ -762,5 +762,79 @@ runTests({
       ],
     },
 
+    {
+      capability: 'include multiple string prop equalities',
+      input: {
+        styles: [
+          {
+            '[work="all"][play=0]': 'DullBoy',
+          }
+        ],
+
+        props: {
+          work: 'all',
+          play: 0,
+        },
+      },
+      expected: [
+        'DullBoy',
+      ],
+    },
+
+    {
+      capability: 'not include multiple string prop equalities when some are not valid',
+      input: {
+        styles: [
+          {
+            '[work="all"][play=0]': 'DullBoy',
+          }
+        ],
+
+        props: {
+          work: 'all',
+          play: 1,
+        },
+      },
+      expected: [
+      ],
+    },
+
+    {
+      capability: 'doesn\'t care about whitespace in [prop] selectors',
+      input: {
+        styles: [
+          {
+            '[  work ="all"][ play = 0 ]': 'DullBoy',
+          }
+        ],
+
+        props: {
+          work: 'all',
+          play: 0,
+        },
+      },
+      expected: [
+        'DullBoy'
+      ],
+    },
+
+    {
+      capability: 'include [valid]::pseudo-elements',
+      input: {
+        styles: [
+          {
+            '[valid]::pseudo-element': 'Yep',
+          }
+        ],
+
+        props: {
+          valid: true,
+        },
+      },
+      expected: [
+        {'::pseudo-element': 'Yep'},
+      ],
+    },
+
   ],
 });

--- a/test/getInvalidStyleStates.js
+++ b/test/getInvalidStyleStates.js
@@ -107,5 +107,15 @@ runTests({
       },
       expected: undefined,
     },
+
+    {
+      capability: 'consider all [props] valid',
+      input: {
+        style: {
+          '[valid]': {},
+        },
+      },
+      expected: undefined,
+    },
   ],
 });

--- a/test/getSubComponentStyles.js
+++ b/test/getSubComponentStyles.js
@@ -127,5 +127,26 @@ runTests({
         ],
       },
     },
+
+    {
+      capability: 'handle [propSelectorsBeforeThe]::sub-component',
+      input: {
+        styles: [
+          {
+            '[prop]::sub-component': {
+              color: 'red',
+            },
+          },
+        ],
+      },
+      expected: {
+        root: [],
+        "sub-component": [
+          {
+            '[prop]': {color: 'red'},
+          },
+        ],
+      },
+    },
   ],
 });


### PR DESCRIPTION
Apply styles conditionally based on a component's `props` without the need to write any `getStyleState` boilerplate. Inspired by [CSS attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors).

Only booleans, numbers, and strings are supported.

A second argument, `props`, is now passed to all value callbacks.

Examples:

``` js
[toggled]
[toggled=false]
[favoriteColor="red"]
[favoriteNumber=42]

':base': (styleState, props) => {
  return props.items.length > 0 : 'Selector_hasMany' : 'Selector';
}
```
